### PR TITLE
[Misc] fix test TestPropertyContainerImpls.java fail

### DIFF
--- a/jdk/test/com/alibaba/rcm/TestPropertyContainerImpls.java
+++ b/jdk/test/com/alibaba/rcm/TestPropertyContainerImpls.java
@@ -2,6 +2,7 @@
  * @test
  * @summary Test ResourceType.SYSTEM_PROPERTY for tenant and wisp implementations
  * @library /lib/testlibrary
+ * @requires ( os.arch == "amd64" ) & ( os.family == "linux" )
  * @run main/othervm -Dcom.alibaba.resourceContainer.propertyIsolation=true -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 TestPropertyContainerImpls wisp
  * @run main/othervm -Dcom.alibaba.resourceContainer.propertyIsolation=true -XX:+MultiTenant TestPropertyContainerImpls tenant
  */


### PR DESCRIPTION
Summary: fix jdk/test/com/alibaba/rcm/TestPropertyContainerImpls.java test run fail because of "MultiTenant only works on Linux x64 platform"

Test Plan: CI pipeline

Reviewed-by: joeylee.lz, lvfei.lv

Issue: https://github.com/alibaba/dragonwell8/issues/337

CR: