### PR TITLE
[Wisp] Fix missing oops_do for WispThread

### DIFF
--- a/hotspot/src/share/vm/runtime/coroutine.cpp
+++ b/hotspot/src/share/vm/runtime/coroutine.cpp
@@ -965,6 +965,10 @@ const char* WispThread::print_blocking_status(int status) {
   }
 }
 
+void WispThread::oops_do(OopClosure *f, CLDClosure *cld_f, CodeBlobClosure *cf) {
+  f->do_oop((oop*) &_threadObj);
+}
+
 void Coroutine::after_safepoint(JavaThread* thread) {
   assert(Thread::current() == thread, "sanity check");
 

--- a/hotspot/src/share/vm/runtime/coroutine.hpp
+++ b/hotspot/src/share/vm/runtime/coroutine.hpp
@@ -445,6 +445,9 @@ public:
     return thread->is_Wisp_thread() ? (WispThread*) thread :
       ((JavaThread*) thread)->current_coroutine()->wisp_thread();
   }
+
+  // Memory operations
+  void oops_do(OopClosure* f, CLDClosure* cld_f, CodeBlobClosure* cf);
 };
 
 // we supported coroutine stealing for following native calls:

--- a/hotspot/src/share/vm/runtime/thread.cpp
+++ b/hotspot/src/share/vm/runtime/thread.cpp
@@ -3094,6 +3094,9 @@ void JavaThread::oops_do(OopClosure* f, CLDClosure* cld_f, CodeBlobClosure* cf) 
     Coroutine* current = _coroutine_list;
     do {
       current->oops_do(f, cld_f, cf);
+      if (UseWispMonitor) {
+        current->wisp_thread()->oops_do(f, cld_f, cf);
+      }
       current = current->next();
     } while (current != _coroutine_list);
   }

--- a/hotspot/src/share/vm/runtime/thread.hpp
+++ b/hotspot/src/share/vm/runtime/thread.hpp
@@ -818,6 +818,7 @@ typedef void (*ThreadFunction)(JavaThread*, TRAPS);
 
 class JavaThread: public Thread {
   friend class VMStructs;
+  friend class WispThread;
  private:
   JavaThread*    _next;                          // The next thread in the Threads list
   oop            _threadObj;                     // The Java level thread object


### PR DESCRIPTION
Summary: Wisp unfortunately missed doing do_oop() for WispThread, which is corresponded to a Coroutine data structure. We shall add it.

Test Plan: all wisp tests

Reviewed-by: yuleil, sanhong

Issue: #189