### PR TITLE
[Misc] disable wisp testcase Wisp2TimerRemoveTest.java temporarily

### DIFF
--- a/jdk/test/com/alibaba/wisp2/Wisp2TimerRemoveTest.java
+++ b/jdk/test/com/alibaba/wisp2/Wisp2TimerRemoveTest.java
@@ -24,6 +24,7 @@
  * @library /lib/testlibrary
  * @summary verify canceled timers are removed ASAP
  * @requires os.family == "linux"
+ * @ignore
  * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 Wisp2TimerRemoveTest
  * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 -Dcom.alibaba.wisp.highPrecisionTimer=true  Wisp2TimerRemoveTest
  */

--- a/jdk/test/com/alibaba/wisp2/Wisp2TimerRemoveTest.java
+++ b/jdk/test/com/alibaba/wisp2/Wisp2TimerRemoveTest.java
@@ -24,9 +24,8 @@
  * @library /lib/testlibrary
  * @summary verify canceled timers are removed ASAP
  * @requires os.family == "linux"
- * @ignore
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 Wisp2TimerRemoveTest
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 -Dcom.alibaba.wisp.highPrecisionTimer=true  Wisp2TimerRemoveTest
+ * @run main/othervm/manual -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 Wisp2TimerRemoveTest
+ * @run main/othervm/manual -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 -Dcom.alibaba.wisp.highPrecisionTimer=true  Wisp2TimerRemoveTest
  */
 
 import com.alibaba.wisp.engine.WispEngine;


### PR DESCRIPTION
Summary: disable wisp testcase com/alibaba/wisp2/Wisp2TimerRemoveTest.java temporarily

Test Plan: CI pipeline

Reviewed-by: lei.yul, lvfei.lv

Issue: https://github.com/alibaba/dragonwell8/issues/360