### PR TITLE
[Misc] fix testcase bug TestG1OldAllocationPendingStackTrace.java

### DIFF
--- a/jdk/test/jdk/jfr/event/gc/stacktrace/TestG1OldAllocationPendingStackTrace.java
+++ b/jdk/test/jdk/jfr/event/gc/stacktrace/TestG1OldAllocationPendingStackTrace.java
@@ -31,7 +31,7 @@ package jdk.jfr.event.gc.stacktrace;
  *
  *
  * @library /lib /
- * @run main/othervm -XX:MaxNewSize=10M -Xmx128M -XX:+UseG1GC -XX:+PrintGCDetails -XX:+PrintGC jdk.jfr.event.gc.stacktrace.TestG1OldAllocationPendingStackTrace
+ * @run main/othervm -XX:MaxNewSize=10M -Xmx100M -XX:+UseG1GC -XX:+PrintGCDetails -XX:+PrintGC jdk.jfr.event.gc.stacktrace.TestG1OldAllocationPendingStackTrace
  */
 public class TestG1OldAllocationPendingStackTrace {
 


### PR DESCRIPTION
Summary: fix testcase bug TestG1OldAllocationPendingStackTrace.java, which intermittently fail on linux-x64

Test Plan: CI pipeline

Reviewed-by: lei.yul, lvfei.lv

Issue: https://github.com/alibaba/dragonwell8/issues/367