### PR TITLE
[Misc] fix testcase bug TestClassLoaderLeak.java

### DIFF
--- a/jdk/test/jdk/jfr/event/oldobject/TestClassLoaderLeak.java
+++ b/jdk/test/jdk/jfr/event/oldobject/TestClassLoaderLeak.java
@@ -45,7 +45,7 @@ import jdk.test.lib.jfr.Events;
  *
  * @library /lib /
  *
- * @run main/othervm -XX:TLABSize=2k jdk.jfr.event.oldobject.TestClassLoaderLeak
+ * @run main/othervm -XX:TLABSize=2k -Xmx128M jdk.jfr.event.oldobject.TestClassLoaderLeak
  */
 public class TestClassLoaderLeak {
 


### PR DESCRIPTION
Summary: This test implicitly wants at least one GC cycle to happen so that ObjectSampler::oop_storage_gc_notification turns the sampled objects "old". An easy way to do this is to trim the Java heap size. 

Test Plan: CI pipeline

Reviewed-by: lei.yul, lvfei.lv

Issue: https://github.com/alibaba/dragonwell8/issues/369