### PR TITLE
[Misc] fix testcase bug Test8233197.sh

### DIFF
--- a/hotspot/test/runtime/8233197/Test8233197.sh
+++ b/hotspot/test/runtime/8233197/Test8233197.sh
@@ -110,6 +110,7 @@ case "$ARCH" in
       ARCH=arm
     else
       ARCH=aarch64
+      unset COMP_FLAG
     fi
     ;;
   i586)
@@ -151,3 +152,4 @@ $gcc_cmd -shared -o libJvmtiAgent.so libJvmtiAgent.o
 
 "$TESTJAVA/bin/java" $TESTVMOPTS -agentlib:JvmtiAgent -cp $(pwd) T > T.out
 exit $?
+


### PR DESCRIPTION
Summary: fix testcase bug hotspot/test/runtime/8233197/Test8233197.sh, which gcc not support -m64 option on linux-aarch64 platform

Test Plan: CI pipeline

Reviewed-by: lei.yul, lvfei.lv

Issue: https://github.com/alibaba/dragonwell8/issues/373