### PR TITLE
[Misc] fix testcase bug LookUpAllAddrsTest.sh

### DIFF
--- a/hotspot/test/runtime/8233197/Test8233197.sh
+++ b/hotspot/test/runtime/8233197/Test8233197.sh
@@ -110,6 +110,7 @@ case "$ARCH" in
       ARCH=arm
     else
       ARCH=aarch64
+      unset COMP_FLAG
     fi
     ;;
   i586)
@@ -151,3 +152,4 @@ $gcc_cmd -shared -o libJvmtiAgent.so libJvmtiAgent.o
 
 "$TESTJAVA/bin/java" $TESTVMOPTS -agentlib:JvmtiAgent -cp $(pwd) T > T.out
 exit $?
+

--- a/jdk/test/java/net/Inet4Address/LookUpAllAddrsTest.sh
+++ b/jdk/test/java/net/Inet4Address/LookUpAllAddrsTest.sh
@@ -46,14 +46,14 @@ which gdb
 if [ $? != 0 ]
 then
     echo "Cannot find GDB, please install it!"
-    exit 1
+    exit 0
 fi
 
 which rpm
 if [ $? != 0 ]
 then
     echo Cannot find tool 'rpm', unsupported platform
-    exit 1
+    exit 0
 fi
 
 GLIBC_VER_MAJOR=$(rpm -qa | sort | uniq | perl -e 'for (<>) { if ($_ =~ /^glibc-(\d+)\.(\d+)\D\S+/ ) { print "$1\n"; exit; } }')


### PR DESCRIPTION
Summary: fix testcase bug jdk/test/java/net/Inet4Address/LookUpAllAddrsTest.sh. Referring to the practice of the upstream openjdk community, such as jdk/test/java/net/InetAddress/ptr/lookup.sh, when the test condition are not met, return 0 to exit

Test Plan: CI pipeline

Reviewed-by: lei.yul, lvfei.lv

Issue: https://github.com/alibaba/dragonwell8/issues/375