### PR TITLE
[Misc] fix jwarmup/issue9780156.sh run fail on ubuntu

### DIFF
--- a/hotspot/test/jwarmup/TestCheckIfCompilationIsComplete.sh
+++ b/hotspot/test/jwarmup/TestCheckIfCompilationIsComplete.sh
@@ -100,7 +100,7 @@ ${JAVA} -XX:-TieredCompilation -XX:-UseSharedSpaces -XX:+CompilationWarmUpRecord
 sleep 1
 ${JAVA} -XX:-TieredCompilation -XX:-UseSharedSpaces -XX:+CompilationWarmUp -XX:+PrintCompilation -XX:+PrintCompilationWarmUpDetail -XX:CompilationWarmUpLogfile=./jitwarmup.log -cp ${TESTCLASSES} ${TEST_CLASS} compilation > output.txt  2>&1
 
-function assert()
+assert()
 {
   i=0
   notify_line_no=0
@@ -109,15 +109,16 @@ function assert()
     i=$(($i+1))
     echo $i
     echo $line
-    if [[ $line =~ "Compilation" ]]; then
+    echo $line | grep Compilation
+    if [ 0 -eq $? ]; then
       notify_line_no=$i
       echo "notify_line_no is $notify_line_no"
     fi
   done < output.txt
-  if [[ $notify_line_no == $(($i-1)) ]]; then
+  if [ $notify_line_no -eq $(($i-1)) ]; then
     exit 0
   else
-    exit -1
+    exit 1
   fi
 }
 

--- a/hotspot/test/jwarmup/TestDisableMethodData.sh
+++ b/hotspot/test/jwarmup/TestDisableMethodData.sh
@@ -141,7 +141,7 @@ sleep 1
 ${JAVA} -XX:-Inline -XX:CompilationWarmUpDeoptTime=3 -XX:CompileCommand=exclude,*.foo -XX:-TieredCompilation -XX:-UseSharedSpaces -XX:+CompilationWarmUp -XX:+PrintCompilation -XX:+PrintCompilationWarmUpDetail -XX:CompilationWarmUpLogfile=./jitwarmup.log -cp ${TESTCLASSES} ${TEST_CLASS} compilation > output.txt  2>&1
 cat output.txt
 
-function assert()
+assert()
 {
   i=0
   notify_line_no=0
@@ -150,14 +150,16 @@ function assert()
     i=$(($i+1))
     echo $i
     echo $line
-    if [[ $line =~ "made not entrant" ]]; then
+    echo $line | grep "made not entrant"
+    if [ 0 -eq $? ]; then
       deopt_line_no=$i
     fi
-    if [[ $line =~ "re-compilation" ]]; then
+    echo $line | grep "re-compilation"
+    if [ 0 -eq $? ]; then
       recom_line_no=$i
     fi
   done < output.txt
-  if [[ $deopt_line_no > $recom_line_no ]]; then
+  if [ $deopt_line_no -gt $recom_line_no ]; then
     echo "deoptimization happens after normal c2 compilation, it is OK."
     exit 0
   else

--- a/hotspot/test/jwarmup/TestNotDeoptJITMethod.sh
+++ b/hotspot/test/jwarmup/TestNotDeoptJITMethod.sh
@@ -122,12 +122,12 @@ ${JAVA} -XX:-TieredCompilation -XX:+CompilationWarmUpRecording -XX:-ClassUnloadi
 sleep 1
 ${JAVA} -XX:-TieredCompilation -XX:+CompilationWarmUp -XX:-UseSharedSpaces -XX:+PrintCompilation -XX:+PrintCompilationWarmUpDetail -Xbatch -XX:CompilationWarmUpLogfile=./jitwarmup.log -XX:+CompilationWarmUpExplicitDeopt -XX:CompilationWarmUpDeoptTime=1200 -XX:-UseOnStackReplacement -cp ${TESTCLASSES} ${TEST_CLASS} compilation > output.txt  2>&1
 
-function check_output()
+check_output()
 {
   #TmpTestNotDeoptJITMethod.foo2 should be re-compiled by jit
   skip_messages=`grep "skip deoptimize TmpTestNotDeoptJITMethod.foo2" output.txt|wc -l`
-  if (( $skip_message -ne 1 )); then
-    exit -1
+  if [ 1 -ne $skip_messages ] ; then
+    exit 1
   fi
 
   exit 0

--- a/hotspot/test/jwarmup/TestNotifyDeopt.sh
+++ b/hotspot/test/jwarmup/TestNotifyDeopt.sh
@@ -109,18 +109,18 @@ ${JAVA} -XX:-TieredCompilation -XX:-UseSharedSpaces -XX:+CompilationWarmUpRecord
 sleep 1
 ${JAVA} -XX:-TieredCompilation -XX:-UseSharedSpaces -XX:+CompilationWarmUp -XX:+PrintCompilationWarmUpDetail -XX:CompileThreshold=500000 -XX:CompilationWarmUpLogfile=./jitwarmup.log -XX:+CompilationWarmUpExplicitDeopt -XX:CompilationWarmUpDeoptTime=1200 -cp ${TESTCLASSES} ${TEST_CLASS} compilation > output.txt  2>&1
 
-function check_output()
+check_output()
 {
   # check warning for conflict CompilationWarmUpDeoptTime
   deopt_time_warning=`grep "WARNING : CompilationWarmUpDeoptTime is unused" output.txt|wc -l`
-  if [[ $deopt_time_warning -ne 1 ]]; then
+  if [ $deopt_time_warning -ne 1 ]; then
     echo "err by deopt time $deopt_time_warning"
     exit -1
   fi
 
   # check warmup method is deoptimized
   deopt_method_messages=`grep "WARNING : deoptimize warmup method" output.txt|wc -l`
-  if [[ $deopt_method_messages -eq 0 ]]; then
+  if [ $deopt_method_messages -eq 0 ]; then
     echo "err by deopt messages $deopt_method_messages"
     exit -1
   fi
@@ -135,13 +135,13 @@ function check_output()
     found=0
     for wm in $warmup_methods
     do
-      if [[ $m == $wm ]]; then
+      if [ "${m}" = "${wm}" ]; then
         found=1
       fi
     done
-    if [[ $found -ne 1 ]]; then
+    if [ $found -ne 1 ]; then
       echo "not found $m"
-      exit -1
+      exit 1
     fi
   done
   exit 0

--- a/hotspot/test/jwarmup/TestTieredCompilationInRecording.sh
+++ b/hotspot/test/jwarmup/TestTieredCompilationInRecording.sh
@@ -107,7 +107,7 @@ ${JAVA} -XX:+CompilationWarmUpRecording -XX:-ClassUnloading -XX:-UseSharedSpaces
 sleep 1
 ${JAVA} -XX:-TieredCompilation -XX:+CompilationWarmUp -XX:-UseSharedSpaces -XX:+PrintCompilation -XX:+PrintCompilationWarmUpDetail -XX:CompilationWarmUpLogfile=./jitwarmup.log -cp ${TESTCLASSES} ${TEST_CLASS} startup > output.txt  2>&1
 
-function assert()
+assert()
 {
   i=0
   has_foo2=0
@@ -116,11 +116,12 @@ function assert()
     i=$(($i+1))
     echo $i
     echo $line
-    if [[ $line =~ "foo2" ]]; then
+    echo $line | grep foo2
+    if [ 0 -eq $? ]; then
       has_foo2=$i
     fi
   done < output.txt
-  if [[ $has_foo2 != 0 ]]; then
+  if [ $has_foo2 -ne 0 ]; then
     exit 0
   else
     exit -1

--- a/hotspot/test/jwarmup/issue9780156.sh
+++ b/hotspot/test/jwarmup/issue9780156.sh
@@ -173,21 +173,22 @@ ${JAVA} -verbose:class -XX:-TieredCompilation -XX:-UseSharedSpaces -XX:+Compilat
 sleep 1
 ${JAVA} -verbose:class -XX:-TieredCompilation -XX:-UseSharedSpaces -XX:+CompilationWarmUp -XX:+PrintCompilation -XX:+PrintCompilationWarmUpDetail -XX:CompilationWarmUpLogfile=./jitwarmup.log -cp ${TESTCLASSES} ${TEST_MAIN_CLASS} > output.txt  2>&1
 
-function assert()
+assert()
 {
   i=0
   while read line
   do
     echo $line
-    if [[ $line =~ "Loaded TmpClassB" ]]; then
+    echo $line | grep "Loaded TmpClassB"
+    if [ 0 -eq $? ]; then
       i=$(($i+1))
       echo $i
     fi
   done < output.txt
-  if [[ $i == 3 ]]; then
+  if [ $i -eq 3 ] ; then
     exit 0
   else
-    exit -1
+    exit 1
   fi
 }
 


### PR DESCRIPTION
Summary: By default in ubuntu system, sh points to dash, which causes sh use case execution to report an syntax error. Relate testcase: jwarmup/TestCheckIfCompilationIsComplete.sh jwarmup/TestDisableMethodData.sh jwarmup/TestNotDeoptJITMethod.sh jwarmup/TestNotifyDeopt.sh jwarmup/TestTieredCompilationInRecording.sh jwarmup/issue9780156.sh

Test Plan: CI pipeline

Reviewed-by: kuaiwei.kw, lvfei.lv

Issue: https://github.com/alibaba/dragonwell8/issues/383