### PR TITLE
[Misc] disable wisp testcase CarrierAsPollerTest.java ExecutionTest.java IoTest.java GlobalPollerTest.java temporarily

### DIFF
--- a/jdk/test/ProblemList.txt
+++ b/jdk/test/ProblemList.txt
@@ -428,6 +428,11 @@ com/alibaba/wisp/monitor/PassTokenTest.java generic-all
 com/alibaba/wisp/bug/WispSelectorReadyOpsTest.java generic-all
 com/alibaba/wisp2/NmtTracingWispTaskRecycleTest.java generic-all
 com/alibaba/wisp2/WispControlGroupCpuTest.java generic-all
+com/alibaba/wisp/ExecutionTest.java https://github.com/alibaba/dragonwell8/issues/371 generic-all
+com/alibaba/wisp/IoTest.java https://github.com/alibaba/dragonwell8/issues/371 generic-all
+com/alibaba/wisp/io/GlobalPollerTest.java https://github.com/alibaba/dragonwell8/issues/371 generic-all
+com/alibaba/wisp2/CarrierAsPollerTest.java https://github.com/alibaba/dragonwell8/issues/371 generic-all
+com/alibaba/wisp2/Wisp2TimerRemoveTest.java https://github.com/alibaba/dragonwell8/issues/360 generic-all
 
 # resource limit
 

--- a/jdk/test/com/alibaba/wisp2/Wisp2TimerRemoveTest.java
+++ b/jdk/test/com/alibaba/wisp2/Wisp2TimerRemoveTest.java
@@ -24,8 +24,8 @@
  * @library /lib/testlibrary
  * @summary verify canceled timers are removed ASAP
  * @requires os.family == "linux"
- * @run main/othervm/manual -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 Wisp2TimerRemoveTest
- * @run main/othervm/manual -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 -Dcom.alibaba.wisp.highPrecisionTimer=true  Wisp2TimerRemoveTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 Wisp2TimerRemoveTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 -Dcom.alibaba.wisp.highPrecisionTimer=true  Wisp2TimerRemoveTest
  */
 
 import com.alibaba.wisp.engine.WispEngine;


### PR DESCRIPTION
Summary: disable wisp testcase com/alibaba/wisp2/CarrierAsPollerTest.java com/alibaba/wisp/ExecutionTest.java com/alibaba/wisp/IoTest.java com/alibaba/wisp/io/GlobalPollerTest.java temporarily

Test Plan: CI pipeline

Reviewed-by: lei.yul, lvfei.lv

Issue: https://github.com/alibaba/dragonwell8/issues/371