### PR TITLE
[Misc] fix SplittableRandomTest.java intermittently timeout

### DIFF
--- a/jdk/test/java/util/SplittableRandom/SplittableRandomTest.java
+++ b/jdk/test/java/util/SplittableRandom/SplittableRandomTest.java
@@ -36,8 +36,8 @@ import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * @test
- * @run testng SplittableRandomTest
- * @run testng/othervm -Djava.util.secureRandomSeed=true SplittableRandomTest
+ * @run testng/othervm -Djava.security.egd=file:/dev/urandom SplittableRandomTest
+ * @run testng/othervm -Djava.security.egd=file:/dev/urandom -Djava.util.secureRandomSeed=true SplittableRandomTest
  * @summary test methods on SplittableRandom
  * @key randomness
  */


### PR DESCRIPTION
Summary: fix jdk/test/java/util/SplittableRandom/SplittableRandomTest.java intermittently fail, use /dev/urandom instead of /dev/random to avoid block for SecureRandom API

Test Plan: CI pipeline

Reviewed-by: lvfei.lv, lei.yul

Issue: https://github.com/alibaba/dragonwell8/issues/428