### PR TITLE
[Wisp] Keep aligning Socket.isConnected() with the normal OpenJDK returning result for ServerSocket.accept()

### DIFF
--- a/jdk/src/share/classes/java/net/ServerSocket.java
+++ b/jdk/src/share/classes/java/net/ServerSocket.java
@@ -568,7 +568,9 @@ class ServerSocket implements java.io.Closeable {
         if (!isBound())
             throw new SocketException("Socket is not bound yet");
         if (WispEngine.transparentWispSwitch()) {
-            return asyncImpl.accept();
+            Socket s = asyncImpl.accept();
+            s.setConnected();
+            return s;
         }
         Socket s = new Socket((SocketImpl) null);
         implAccept(s);

--- a/jdk/src/share/classes/java/net/Socket.java
+++ b/jdk/src/share/classes/java/net/Socket.java
@@ -760,8 +760,6 @@ class Socket implements java.io.Closeable {
     }
 
     void setConnected() {
-        if (WispEngine.transparentWispSwitch())
-            throw new UnsupportedOperationException();
         connected = true;
     }
 

--- a/jdk/test/com/alibaba/wisp/io/ServerSocketConnectionTest.java
+++ b/jdk/test/com/alibaba/wisp/io/ServerSocketConnectionTest.java
@@ -84,8 +84,29 @@ public class ServerSocketConnectionTest {
         }
     }
 
+    private static void testIsConnectedAfterAcception() throws Exception {
+        Socket s1 = null;
+        try (ServerSocket ss = new ServerSocket(0)) {
+            InetAddress ia = InetAddress.getLocalHost();
+            InetSocketAddress isa = new InetSocketAddress(ia, ss.getLocalPort());
+            new Socket().connect(isa);
+            s1 = ss.accept();
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException("Test Failed!");
+        } finally {
+            if (s1 != null) {
+                assertTrue(s1.isConnected());
+                s1.close();
+                // We should return true even after the socket is closed, to keep align with OpenJDK.
+                assertTrue(s1.isConnected());
+            }
+        }
+    }
+
     public static void main(String args[]) throws Exception {
         testIsConnectedAfterClosing();
         testIsConnectedAfterConnectionFailure();
+        testIsConnectedAfterAcception();
     }
 }


### PR DESCRIPTION
Summary: Same as #438: we have another path ServerSocket.accept() to cover.

Test Plan: ServerSocketConnectionTest.java

Reviewed-by: D-D-H, yuleil

Issue: #437