### PR TITLE
[Misc] Fix DRAGONWELL_JAVA_TOOL_OPTIONS_JDK_ONLY not effect for JDK b…

### DIFF
--- a/hotspot/make/aix/makefiles/mapfile-vers-debug
+++ b/hotspot/make/aix/makefiles/mapfile-vers-debug
@@ -30,7 +30,6 @@ SUNWprivate_1.1 {
                 JNI_CreateJavaVM;
                 JNI_GetCreatedJavaVMs;
                 JNI_GetDefaultJavaVMInitArgs;
-                JNI_SetRunningFromJava;
 
                 # JVM
                 JVM_Accept;

--- a/hotspot/make/aix/makefiles/mapfile-vers-product
+++ b/hotspot/make/aix/makefiles/mapfile-vers-product
@@ -30,7 +30,6 @@ SUNWprivate_1.1 {
                 JNI_CreateJavaVM;
                 JNI_GetCreatedJavaVMs;
                 JNI_GetDefaultJavaVMInitArgs;
-                JNI_SetRunningFromJava;
 
                 # JVM
                 JVM_Accept;

--- a/hotspot/make/linux/makefiles/mapfile-vers-debug
+++ b/hotspot/make/linux/makefiles/mapfile-vers-debug
@@ -30,7 +30,6 @@ SUNWprivate_1.1 {
                 JNI_CreateJavaVM;
                 JNI_GetCreatedJavaVMs;
                 JNI_GetDefaultJavaVMInitArgs;
-                JNI_SetRunningFromJava;
 
                 # JVM
                 JVM_Accept;

--- a/hotspot/make/linux/makefiles/mapfile-vers-product
+++ b/hotspot/make/linux/makefiles/mapfile-vers-product
@@ -30,7 +30,6 @@ SUNWprivate_1.1 {
                 JNI_CreateJavaVM;
                 JNI_GetCreatedJavaVMs;
                 JNI_GetDefaultJavaVMInitArgs;
-                JNI_SetRunningFromJava;
 
                 # JVM
                 JVM_Accept;

--- a/hotspot/make/solaris/makefiles/mapfile-vers
+++ b/hotspot/make/solaris/makefiles/mapfile-vers
@@ -30,7 +30,6 @@ SUNWprivate_1.1 {
                 JNI_CreateJavaVM;
                 JNI_GetCreatedJavaVMs;
                 JNI_GetDefaultJavaVMInitArgs;
-                JNI_SetRunningFromJava;
 
                 # JVM
                 JVM_Accept;

--- a/hotspot/src/share/vm/prims/jni.cpp
+++ b/hotspot/src/share/vm/prims/jni.cpp
@@ -82,7 +82,6 @@
 #include "utilities/dtrace.hpp"
 #include "utilities/events.hpp"
 #include "utilities/histogram.hpp"
-#include "runtime/arguments.hpp"
 #ifdef TARGET_OS_FAMILY_linux
 # include "os_linux.inline.hpp"
 #endif
@@ -5682,10 +5681,6 @@ jint JNICALL jni_AttachCurrentThreadAsDaemon(JavaVM *vm, void **penv, void *_arg
                                                  ret);
 #endif /* USDT2 */
   return ret;
-}
-
-_JNI_IMPORT_OR_EXPORT_ void JNICALL JNI_SetRunningFromJava(jboolean flag) {
-    Arguments::set_running_from_java(flag);
 }
 
 

--- a/hotspot/src/share/vm/prims/jni.h
+++ b/hotspot/src/share/vm/prims/jni.h
@@ -1940,8 +1940,6 @@ JNI_CreateJavaVM(JavaVM **pvm, void **penv, void *args);
 _JNI_IMPORT_OR_EXPORT_ jint JNICALL
 JNI_GetCreatedJavaVMs(JavaVM **, jsize, jsize *);
 
-_JNI_IMPORT_OR_EXPORT_ void JNICALL
-JNI_SetRunningFromJava(jboolean flag);
 
 /* Defined by native libraries. */
 JNIEXPORT jint JNICALL

--- a/hotspot/src/share/vm/runtime/arguments.hpp
+++ b/hotspot/src/share/vm/runtime/arguments.hpp
@@ -359,9 +359,6 @@ class Arguments : AllStatic {
   static exit_hook_t      _exit_hook;
   static vfprintf_hook_t  _vfprintf_hook;
 
-  // Running from java command
-  static bool _running_from_java;
-
   // System properties
   static bool add_property(const char* prop);
 
@@ -377,13 +374,14 @@ class Arguments : AllStatic {
   static void process_java_launcher_argument(const char*, void*);
   static void process_java_compiler_argument(char* arg);
   static jint parse_options_environment_variable(const char* name, SysClassPath* scp_p, bool* scp_assembly_required_p);
-  static jint parse_java_tool_options_environment_variable(SysClassPath* scp_p, bool* scp_assembly_required_p);
-  static jint parse_dragonwell_options_environment_variable(SysClassPath* scp_p, bool* scp_assembly_required_p);
+  static jint parse_java_tool_options_environment_variable(SysClassPath* scp_p, bool* scp_assembly_required_p, bool enable_tool_options);
+  static jint parse_dragonwell_options_environment_variable(SysClassPath* scp_p, bool* scp_assembly_required_p, bool enable_tool_options);
   static jint parse_java_options_environment_variable(SysClassPath* scp_p, bool* scp_assembly_required_p);
   static jint parse_vm_init_args(const JavaVMInitArgs* args);
   static jint parse_each_vm_init_arg(const JavaVMInitArgs* args, SysClassPath* scp_p, bool* scp_assembly_required_p, Flag::Flags origin);
   static jint finalize_vm_init_args(SysClassPath* scp_p, bool scp_assembly_required);
   static bool is_bad_option(const JavaVMOption* option, jboolean ignore, const char* option_type);
+  static bool is_enable_tool_options(const JavaVMInitArgs* args);
 
   static bool is_bad_option(const JavaVMOption* option, jboolean ignore) {
     return is_bad_option(option, ignore, NULL);
@@ -608,9 +606,6 @@ class Arguments : AllStatic {
   // Operation modi
   static Mode mode()                { return _mode; }
   static bool is_interpreter_only() { return mode() == _int; }
-
-  static void set_running_from_java(jboolean running_from_java) { _running_from_java = (running_from_java == JNI_TRUE ? true : false); }
-  static bool is_running_from_java() { return _running_from_java; }
 
 
   // Utility: copies src into buf, replacing "%%" with "%" and "%p" with pid.

--- a/jdk/src/share/bin/java.c
+++ b/jdk/src/share/bin/java.c
@@ -167,7 +167,6 @@ static jboolean IsWildCardEnabled();
 static jlong threadStackSize    = 0;  /* stack size of the new thread */
 static jlong maxHeapSize        = 0;  /* max heap size */
 static jlong initialHeapSize    = 0;  /* inital heap size */
-static jboolean runFromJava     = JNI_FALSE; /* starts from java command */
 
 /*
  * Entry point.
@@ -204,7 +203,6 @@ JLI_Launch(int argc, char ** argv,              /* main argc, argc */
     _is_java_args = javaargs;
     _wc_enabled = cpwildcard;
     _ergo_policy = ergo;
-    runFromJava = jargc > 0;
 
     InitLauncher(javaw);
     DumpState();
@@ -1239,7 +1237,6 @@ InitializeJVM(JavaVM **pvm, JNIEnv **penv, InvocationFunctions *ifn)
                    i, args.options[i].optionString);
     }
 
-    ifn->SetRunningFromJava(!printVersion && runFromJava);
     r = ifn->CreateJavaVM(pvm, (void **)penv, &args);
     JLI_MemFree(options);
     return r == JNI_OK;

--- a/jdk/src/share/bin/java.h
+++ b/jdk/src/share/bin/java.h
@@ -80,13 +80,11 @@
 typedef jint (JNICALL *CreateJavaVM_t)(JavaVM **pvm, void **env, void *args);
 typedef jint (JNICALL *GetDefaultJavaVMInitArgs_t)(void *args);
 typedef jint (JNICALL *GetCreatedJavaVMs_t)(JavaVM **vmBuf, jsize bufLen, jsize *nVMs);
-typedef void (JNICALL *SetRunningFromJava_t)(jboolean flag);
 
 typedef struct {
     CreateJavaVM_t CreateJavaVM;
     GetDefaultJavaVMInitArgs_t GetDefaultJavaVMInitArgs;
     GetCreatedJavaVMs_t GetCreatedJavaVMs;
-    SetRunningFromJava_t SetRunningFromJava;
 } InvocationFunctions;
 
 int

--- a/jdk/src/solaris/bin/java_md_solinux.c
+++ b/jdk/src/solaris/bin/java_md_solinux.c
@@ -917,14 +917,6 @@ LoadJavaVM(const char *jvmpath, InvocationFunctions *ifn)
         return JNI_FALSE;
     }
 
-    ifn->SetRunningFromJava = (SetRunningFromJava_t)
-        dlsym(libjvm, "JNI_SetRunningFromJava");
-    if (ifn->SetRunningFromJava == NULL) {
-        JLI_ReportErrorMessage(DLL_ERROR2, jvmpath, dlerror());
-        return JNI_FALSE;
-    }
-
-
     return JNI_TRUE;
 }
 

--- a/jdk/src/windows/bin/java_md.c
+++ b/jdk/src/windows/bin/java_md.c
@@ -403,8 +403,6 @@ LoadJavaVM(const char *jvmpath, InvocationFunctions *ifn)
         (void *)GetProcAddress(handle, "JNI_CreateJavaVM");
     ifn->GetDefaultJavaVMInitArgs =
         (void *)GetProcAddress(handle, "JNI_GetDefaultJavaVMInitArgs");
-    ifn->SetRunningFromJava =
-        (void *)GetProcAddress(handle, "JNI_SetRunningFromJava");
     if (ifn->CreateJavaVM == 0 || ifn->GetDefaultJavaVMInitArgs == 0) {
         JLI_ReportErrorMessage(JNI_ERROR1, (char *)jvmpath);
         return JNI_FALSE;

--- a/jdk/test/com/alibaba/TestVendorVMOptions.java
+++ b/jdk/test/com/alibaba/TestVendorVMOptions.java
@@ -69,7 +69,7 @@ public class TestVendorVMOptions {
         outputAnalyzer.shouldHaveExitValue(0);
 
         // enable a invalid JAVA_OPTIONS and DRAGONWELL_JAVA_TOOL_OPTIONS_JDK_ONLY jps
-        Process p = Runtime.getRuntime().exec(System.getProperty("test.jdk") + "/bin/jps ", new String[]{"JAVA_OPTIONS=invliad", "DRAGONWELL_JAVA_TOOL_OPTIONS_JDK_ONLY=true"});
+        Process p = Runtime.getRuntime().exec(System.getProperty("test.jdk") + "/bin/jps ", new String[]{"JAVA_TOOL_OPTIONS=invliad", "DRAGONWELL_JAVA_TOOL_OPTIONS_JDK_ONLY=true"});
         outputAnalyzer = new OutputAnalyzer(p);
         outputAnalyzer.shouldHaveExitValue(0);
 


### PR DESCRIPTION
[Misc] Fix DRAGONWELL_JAVA_TOOL_OPTIONS_JDK_ONLY not effect for JDK built in tools
Summary: See this issue:https://github.com/alibaba/dragonwell8/issues/406. "DRAGONWELL_JAVA_TOOL_OPTIONS_JDK_ONLY" should effect for jps,jstack and etc.
Reviewed-by: yuleil,D-D-H
Issue: https://github.com/alibaba/dragonwell8/issues/406
Test Plan: TestVendorVMOptions.java