### PR TITLE
[JIT] Fix a deadloop in c2 compiler

### DIFF
--- a/hotspot/src/share/vm/runtime/globals_ext.hpp
+++ b/hotspot/src/share/vm/runtime/globals_ext.hpp
@@ -160,6 +160,9 @@
           "code sweeper trigger period time (in seconds, "                  \
           "0 means disable periodly trigger)" )                             \
                                                                             \
+  product(intx, MemNodeLoopContinueThres, 200,                              \
+          "Max coninuation number in MemNode loop")                         \
+                                                                            \
   //add new AJVM specific flags here
 
 


### PR DESCRIPTION
Summary: A dead loop was observed in C2 optimizations. This deadloop is very rare and hard to reproduce. A conservative way is used to fix this issue. If a dead loop is detected. Just stop compiling this method at level 4.

Reviewed-by: kuaiwei.kw, yueshi.zwj

Issue: https://github.com/alibaba/dragonwell8/issues/455

Test Plan: internal tests