### PR TITLE
[Misc] Adding barriers on JVM

### DIFF
--- a/hotspot/src/share/vm/classfile/classLoaderData.hpp
+++ b/hotspot/src/share/vm/classfile/classLoaderData.hpp
@@ -178,8 +178,8 @@ class ClassLoaderData : public CHeapObj<mtClass> {
   Dependencies _dependencies; // holds dependencies from this class loader
                               // data to others.
 
-  Metaspace * _metaspace;  // Meta-space where meta-data defined by the
-                           // classes in the class loader are allocated.
+  Metaspace * volatile _metaspace;  // Meta-space where meta-data defined by the
+                                    // classes in the class loader are allocated.
   Mutex* _metaspace_lock;  // Locks the metaspace for allocations and setup.
   bool _unloading;         // true if this class loader goes away
   bool _keep_alive;        // if this CLD is kept alive without a keep_alive_object().
@@ -187,7 +187,7 @@ class ClassLoaderData : public CHeapObj<mtClass> {
   volatile int _claimed;   // true if claimed, for example during GC traces.
                            // To avoid applying oop closure more than once.
                            // Has to be an int because we cas it.
-  Klass* _klasses;         // The classes defined by the class loader.
+  Klass* volatile _klasses;   // The classes defined by the class loader.
 
   ChunkedHandleList _handles; // Handles to constant pool arrays, etc, which
                               // have the same life cycle of the corresponding ClassLoader.
@@ -216,8 +216,6 @@ class ClassLoaderData : public CHeapObj<mtClass> {
 
   ClassLoaderData(Handle h_class_loader, bool is_anonymous, Dependencies dependencies);
   ~ClassLoaderData();
-
-  void set_metaspace(Metaspace* m) { _metaspace = m; }
 
   Mutex* metaspace_lock() const { return _metaspace_lock; }
 

--- a/hotspot/src/share/vm/gc_implementation/parNew/parCardTableModRefBS.cpp
+++ b/hotspot/src/share/vm/gc_implementation/parNew/parCardTableModRefBS.cpp
@@ -353,6 +353,8 @@ process_chunk_boundaries(Space* sp,
                               " and max_to_do " PTR_FORMAT " + " PTR_FORMAT " = " PTR_FORMAT,
                               limit_card, last_block, last_block_size, max_to_do);)
         }
+        // Looks like need loadload before reading LNC array
+        OrderAccess::loadload();
         assert(0 < cur_chunk_index+1 && cur_chunk_index+1 < lowest_non_clean_chunk_size,
                "Bounds error.");
         // It is possible that a dirty card for the last object may have been

--- a/hotspot/src/share/vm/oops/instanceKlass.cpp
+++ b/hotspot/src/share/vm/oops/instanceKlass.cpp
@@ -1271,21 +1271,21 @@ void InstanceKlass::call_class_initializer_impl(instanceKlassHandle this_oop, TR
 
 void InstanceKlass::mask_for(methodHandle method, int bci,
   InterpreterOopMap* entry_for) {
-  // Dirty read, then double-check under a lock.
-  if (_oop_map_cache == NULL) {
-    // Otherwise, allocate a new one.
+  // Lazily create the _oop_map_cache at first request
+  // Lock-free access requires load_ptr_acquire.
+  OopMapCache* oop_map_cache =
+          static_cast<OopMapCache*>(OrderAccess::load_ptr_acquire(&_oop_map_cache));
+  if (oop_map_cache == NULL) {
     MutexLocker x(OopMapCacheAlloc_lock);
-    // First time use. Allocate a cache in C heap
-    if (_oop_map_cache == NULL) {
-      // Release stores from OopMapCache constructor before assignment
-      // to _oop_map_cache. C++ compilers on ppc do not emit the
-      // required memory barrier only because of the volatile
-      // qualifier of _oop_map_cache.
-      OrderAccess::release_store_ptr(&_oop_map_cache, new OopMapCache());
+    // Check if _oop_map_cache was allocated while we were waiting for this lock
+    if ((oop_map_cache = _oop_map_cache) == NULL) {
+      oop_map_cache = new OopMapCache();
+      // Ensure _oop_map_cache is stable, since it is examined without a lock
+      OrderAccess::release_store_ptr(&_oop_map_cache, oop_map_cache);
     }
   }
-  // _oop_map_cache is constant after init; lookup below does is own locking.
-  _oop_map_cache->lookup(method, bci, entry_for);
+  // _oop_map_cache is constant after init; lookup below does its own locking.
+  oop_map_cache->lookup(method, bci, entry_for);
 }
 
 

--- a/hotspot/src/share/vm/utilities/bitMap.inline.hpp
+++ b/hotspot/src/share/vm/utilities/bitMap.inline.hpp
@@ -54,7 +54,7 @@ inline bool BitMap::par_set_bit(idx_t bit) {
   verify_index(bit);
   volatile bm_word_t* const addr = word_addr(bit);
   const bm_word_t mask = bit_mask(bit);
-  bm_word_t old_val = *addr;
+  bm_word_t old_val = OrderAccess::load_acquire(addr);
 
   do {
     const bm_word_t new_val = old_val | mask;
@@ -75,7 +75,7 @@ inline bool BitMap::par_clear_bit(idx_t bit) {
   verify_index(bit);
   volatile bm_word_t* const addr = word_addr(bit);
   const bm_word_t mask = ~bit_mask(bit);
-  bm_word_t old_val = *addr;
+  bm_word_t old_val = OrderAccess::load_acquire(addr);
 
   do {
     const bm_word_t new_val = old_val & mask;


### PR DESCRIPTION
    Summary:  this patch addes mem barriers in JVM.
    Including:
    8154750: Add missing OrderAccess operations to ClassLoaderData
lock-free data structures
    https://bugs.openjdk.org/browse/JDK-8154750
    8233073: Make BitMap accessors more memory ordering friendly
    https://bugs.openjdk.org/browse/JDK-8233073
    8221584: SIGSEGV in os::PlatformEvent::unpark() in
JvmtiRawMonitor::raw_exit while posting
    method exit event
    https://bugs.openjdk.org/browse/JDK-8221584
    8166197: assert(RelaxAssert || w != Thread::current()->_MutexEvent)
failed: invariant
    8164207: Checking missing load-acquire in relation to _pd_set in
dictionary.cpp
    https://bugs.openjdk.org/browse/JDK-8164207
    and adding a loadload barrier in CMS

    Test Plan: e-commerce online tests

    Reviewers: maoliang.ml, lxw263044

    Issue: https://github.com/alibaba/dragonwell8/issues/457

    Reviewed-by: mmyxym, kuaiwei

    Issue: https://github.com/alibaba/dragonwell8/issues/330