### PR TITLE
[Wisp] Fix potential issues: unbalanced monitors and killed arrayoop pending_unpark

### DIFF
--- a/hotspot/src/cpu/aarch64/vm/sharedRuntime_aarch64.cpp
+++ b/hotspot/src/cpu/aarch64/vm/sharedRuntime_aarch64.cpp
@@ -3132,6 +3132,10 @@ void create_switchTo_contents(MacroAssembler *masm, int start, OopMapSet* oop_ma
     __ strw(temp, Address(old_coroutine, Coroutine::thread_status_offset()));
     __ ldrw(temp, Address(thread, JavaThread::java_call_counter_offset()));
     __ strw(temp, Address(old_coroutine, Coroutine::java_call_counter_offset()));
+    __ ldr(temp, Address(thread, JavaThread::monitor_chunks_offset()));
+    __ str(temp, Address(old_coroutine, Coroutine::monitor_chunks_offset()));
+    __ ldrb(temp, Address(thread, JavaThread::do_not_unlock_if_synchronized_offset()));
+    __ strb(temp, Address(old_coroutine, Coroutine::do_not_unlock_if_synchronized_offset()));
     __ mov(temp, sp);
     __ str(temp, Address(old_stack, CoroutineStack::last_sp_offset())); // str cannot use sp as an argument
   }
@@ -3171,6 +3175,10 @@ void create_switchTo_contents(MacroAssembler *masm, int start, OopMapSet* oop_ma
       __ strw(temp2, Address(temp, java_lang_Thread::thread_status_offset()));
       __ ldrw(temp, Address(target_coroutine, Coroutine::java_call_counter_offset()));
       __ strw(temp, Address(thread, JavaThread::java_call_counter_offset()));
+      __ ldr(temp, Address(target_coroutine, Coroutine::monitor_chunks_offset()));
+      __ str(temp, Address(thread, JavaThread::monitor_chunks_offset()));
+      __ ldrb(temp, Address(target_coroutine, Coroutine::do_not_unlock_if_synchronized_offset()));
+      __ strb(temp, Address(thread, JavaThread::do_not_unlock_if_synchronized_offset()));
 #ifdef ASSERT
       __ str(zr, Address(target_coroutine, Coroutine::handle_area_offset()));
       __ str(zr, Address(target_coroutine, Coroutine::resource_area_offset()));

--- a/hotspot/src/cpu/x86/vm/sharedRuntime_x86_64.cpp
+++ b/hotspot/src/cpu/x86/vm/sharedRuntime_x86_64.cpp
@@ -4517,7 +4517,10 @@ void create_switchTo_contents(MacroAssembler *masm, int start, OopMapSet* oop_ma
     __ movl(Address(old_coroutine, Coroutine::thread_status_offset()), temp);
     __ movl(temp, Address(thread, JavaThread::java_call_counter_offset()));
     __ movl(Address(old_coroutine, Coroutine::java_call_counter_offset()), temp);
-
+    __ movptr(temp, Address(thread, JavaThread::monitor_chunks_offset()));
+    __ movptr(Address(old_coroutine, Coroutine::monitor_chunks_offset()), temp);
+    __ movbool(temp, Address(thread, JavaThread::do_not_unlock_if_synchronized_offset()));
+    __ movbool(Address(old_coroutine, Coroutine::do_not_unlock_if_synchronized_offset()), temp);
     if (EagerAppCDS && !UseSharedSpaces) {
       __ movptr(temp, Address(thread, JavaThread::initiating_loader_offset()));
       __ movptr(Address(old_coroutine, Coroutine::initiating_loader_offset()), temp);
@@ -4562,6 +4565,10 @@ void create_switchTo_contents(MacroAssembler *masm, int start, OopMapSet* oop_ma
       __ movl(Address(temp, java_lang_Thread::thread_status_offset()), temp2);
       __ movl(temp, Address(target_coroutine, Coroutine::java_call_counter_offset()));
       __ movl(Address(thread, JavaThread::java_call_counter_offset()), temp);
+      __ movptr(temp, Address(target_coroutine, Coroutine::monitor_chunks_offset()));
+      __ movptr(Address(thread, JavaThread::monitor_chunks_offset()), temp);
+      __ movbool(temp, Address(target_coroutine, Coroutine::do_not_unlock_if_synchronized_offset()));
+      __ movbool(Address(thread, JavaThread::do_not_unlock_if_synchronized_offset()), temp);
 #ifdef ASSERT
       __ movptr(Address(target_coroutine, Coroutine::handle_area_offset()), (intptr_t)NULL_WORD);
       __ movptr(Address(target_coroutine, Coroutine::resource_area_offset()), (intptr_t)NULL_WORD);

--- a/hotspot/src/share/vm/runtime/coroutine.hpp
+++ b/hotspot/src/share/vm/runtime/coroutine.hpp
@@ -115,12 +115,14 @@ private:
   GrowableArray<Metadata*>* _metadata_handles;
   JavaFrameAnchor _anchor;
   PrivilegedElement*  _privileged_stack_top;
+  MonitorChunk*   _monitor_chunks;
   java_lang_Thread::ThreadStatus _thread_status;
   int             _enable_steal_count;
   int             _java_call_counter;
   int             _last_native_call_counter;
   int             _clinit_call_counter;
   volatile int    _native_call_counter;
+  bool            _do_not_unlock_if_synchronized;
   // AppCDS support
   ClassLoaderData* _initiating_loader;
 
@@ -233,6 +235,8 @@ public:
   static ByteSize active_handles_offset()     { return byte_offset_of(Coroutine, _active_handles); }
   static ByteSize metadata_handles_offset()   { return byte_offset_of(Coroutine, _metadata_handles); }
   static ByteSize privileged_stack_top_offset(){ return byte_offset_of(Coroutine, _privileged_stack_top); }
+  static ByteSize monitor_chunks_offset()     { return byte_offset_of(Coroutine, _monitor_chunks); }
+  static ByteSize do_not_unlock_if_synchronized_offset()     { return byte_offset_of(Coroutine, _do_not_unlock_if_synchronized); }
   static ByteSize last_Java_sp_offset()       {
     return byte_offset_of(Coroutine, _anchor) + JavaFrameAnchor::last_Java_sp_offset();
   }
@@ -431,8 +435,14 @@ public:
 
   virtual bool is_lock_owned(address adr) const {
     CoroutineStack* stack = _coroutine->stack();
-    return stack->stack_base() >= adr &&
-      adr > (stack->stack_base() - stack->stack_size());
+    if (stack->stack_base() > adr && adr >= (stack->stack_base() - stack->stack_size())) {
+      return true;
+    }
+
+    for (MonitorChunk* chunk = monitor_chunks(); chunk != NULL; chunk = chunk->next()) {
+      if (chunk->contains(adr)) return true;
+    }
+    return false;
   }
 
   // we must set ObjectWaiter members before node enqueued(observed by other threads)

--- a/hotspot/src/share/vm/runtime/objectMonitor.cpp
+++ b/hotspot/src/share/vm/runtime/objectMonitor.cpp
@@ -1027,6 +1027,14 @@ void ATTR ObjectMonitor::exit(bool not_suspended, TRAPS) {
        // in native code by throwing an exception.
        // TODO: Throw an IllegalMonitorStateException ?
        TEVENT (Exit - Throw IMSX) ;
+       if (UseWispMonitor) {
+        JavaThread *pt = ((WispThread*)Self)->thread();
+        tty->print_cr("[Wisp] Fatal IMSX: this=%p, pt=%p, current_coroutine=%p, self=%p (stack: %p - %p), _owner=%p, _owner->coro=%p",
+                  this, pt, ((JavaThread*)pt)->current_coroutine(), Self,
+                  ((WispThread*)Self)->coroutine()->stack()->stack_base(),
+                  ((WispThread*)Self)->coroutine()->stack()->stack_base() - ((WispThread*)Self)->coroutine()->stack()->stack_size(),
+                  _owner, ((WispThread*)_owner)->coroutine());
+        }
        assert(false, "Non-balanced monitor enter/exit!");
        if (false) {
           THROW(vmSymbols::java_lang_IllegalMonitorStateException());

--- a/hotspot/src/share/vm/runtime/thread.hpp
+++ b/hotspot/src/share/vm/runtime/thread.hpp
@@ -1011,6 +1011,7 @@ class JavaThread: public Thread {
   bool wisp_preempted() const                    { return _wisp_preempted; }
   void set_wisp_preempted(bool b)                { _wisp_preempted = b; }
 
+  static ByteSize monitor_chunks_offset()        { return byte_offset_of(JavaThread, _monitor_chunks); }
   static ByteSize coroutine_temp_offset()        { return byte_offset_of(JavaThread, _coroutine_temp); }
 
   static ByteSize current_coroutine_offset()     { return byte_offset_of(JavaThread, _current_coroutine); }


### PR DESCRIPTION
Summary: As the title. Backport from dw11.

Testing: test/jdk/com/alibaba/wisp

Reviewers: kuaiwei, yude

Issue: https://github.com/dragonwell-project/dragonwell11/issues/619