### PR TITLE
[JIT] Fix build issues on Windows

### DIFF
--- a/hotspot/make/windows/create_obj_files.sh
+++ b/hotspot/make/windows/create_obj_files.sh
@@ -134,7 +134,7 @@ esac
 
 # Special handling of AI-Extension.
 if [ "${ENABLE_AIEXT}" != "true" ]; then
-  Src_Files_EXCLUDE="${Src_Files_EXCLUDE} aiext.cpp aiExtension.cpp" ;;
+  Src_Files_EXCLUDE="${Src_Files_EXCLUDE} aiext.cpp aiExtension.cpp"
 fi
 
 # Locate all source files in the given directory, excluding files in Src_Files_EXCLUDE.


### PR DESCRIPTION
Summary: Windows build failed to run due to a syntax error in shell script, this patch fixes it.

Testing: CI

Reviewers: JoshuaZhuwj, syqq-q

Issue: https://github.com/dragonwell-project/dragonwell8/issues/748