### PR TITLE
Change the default timout action in initialization

### DIFF
--- a/jdk/src/linux/classes/com/alibaba/wisp/engine/TimeOut.java
+++ b/jdk/src/linux/classes/com/alibaba/wisp/engine/TimeOut.java
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class TimeOut {
     enum Action {
+        INIT,
         JVM_UNPARK,
         JDK_UNPARK,
         RESUME
@@ -67,6 +68,9 @@ public class TimeOut {
      */
     void doAction() {
         switch (action) {
+            case INIT:
+                // only be called in Wisp init process
+                break;
             case RESUME:
                 task.carrier.wakeupTask(task);
                 break;

--- a/jdk/src/linux/classes/com/alibaba/wisp/engine/WispEngine.java
+++ b/jdk/src/linux/classes/com/alibaba/wisp/engine/WispEngine.java
@@ -161,7 +161,8 @@ public class WispEngine extends AbstractExecutorService {
             new ConcurrentLinkedQueue<>().iterator();
             new ConcurrentSkipListMap<>().keySet().iterator();
             WispCarrier carrier = WispCarrier.current();
-            carrier.addTimer(System.nanoTime() + Integer.MAX_VALUE, TimeOut.Action.JDK_UNPARK);
+            // This timer will never be processed
+            carrier.addTimer(System.nanoTime() + Integer.MAX_VALUE, TimeOut.Action.INIT);
             WispCarrier.current().current.timeOut.doAction();
             carrier.cancelTimer();
             carrier.createResumeEntry(new WispTask(carrier, null, false, false));

--- a/jdk/test/com/alibaba/wisp2/MainThreadSleepTest.java
+++ b/jdk/test/com/alibaba/wisp2/MainThreadSleepTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation. Alibaba designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+public class MainThreadSleepTest {
+    public static void main(String[] args) throws Exception {
+        long start = System.nanoTime();
+        // sleep for 10 seconds
+        Thread.sleep(10 * 1000);
+        long end = System.nanoTime();
+        if (end - start < 10 * 1000000000L) {
+            System.err.println("sleep time is less than 10 seconds: " + (end - start) + " ns");
+            System.exit(1);
+        }
+        return;
+    }
+}
+
+
+

--- a/jdk/test/com/alibaba/wisp2/mainThreadSleepTest.sh
+++ b/jdk/test/com/alibaba/wisp2/mainThreadSleepTest.sh
@@ -1,0 +1,49 @@
+# Copyright (c) 2026 Alibaba Group Holding Limited. All Rights Reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation. Alibaba designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+# @test
+# @run shell mainThreadSleepTest.sh
+# @summary Main thread sleep time test
+
+OS=`uname -s`
+case "$OS" in
+  SunOS | Linux | Darwin | AIX )
+    PS=":"
+    FS="/"
+    ;;
+  CYGWIN* )
+    PS=";"
+    FS="/"
+    ;;
+  Windows* )
+    PS=";"
+    FS="\\"
+    ;;
+  * )
+    echo "Unrecognized system!"
+    exit 1;
+    ;;
+esac
+
+# compile
+${COMPILEJAVA}${FS}bin${FS}javac ${TESTJAVACOPTS} ${TESTTOOLVMOPTS} -d ${TESTCLASSPATH} ${TESTSRC}${FS}MainThreadSleepTest.java
+
+# run
+${TESTJAVA}${FS}bin${FS}java ${TESTVMOPTS} -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 -cp ${TESTCLASSPATH} MainThreadSleepTest


### PR DESCRIPTION
Fix #753 

Before this CL, the main thread will call an additional unpark in the init process of WispEngine because the default status of timeout, so the main threads will return immediately in the first Thread.sleep call, which breaks the semantics.

This CL changes the default timeout action for the main thread to INIT to fix this issue.